### PR TITLE
fix: use secondLabelLink.text in secondLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hard Coded "Privacy Policy" in FormConfirmationCheckbox
 
 ## [1.0.1] - 2020-11-03
-
 ### Fixed
 - Props listed with the wrong names in the docs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Hard Coded "Privacy Policy" in FormConfirmationCheckbox
+
 ## [1.0.1] - 2020-11-03
+
 ### Fixed
 - Props listed with the wrong names in the docs.
 

--- a/react/FormConfirmationCheckbox.tsx
+++ b/react/FormConfirmationCheckbox.tsx
@@ -66,7 +66,7 @@ function FormConfirmationCheckbox(props: Props) {
               ),
               secondLink: secondLabelLink && (
                 <LabelLink
-                  text="Privacy Policy"
+                  text={secondLabelLink.text}
                   url={secondLabelLink.url}
                   ordinalPosition="second"
                 />


### PR DESCRIPTION
#### What problem is this solving?

Remove "Policy Privacy" hardcoded text in FormConfirmationCheckbox secondLink 

#### How to test it?

Trust me Mirandinha

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/Z9iAMfODlQG7wLoXKN/giphy.gif)
